### PR TITLE
fix(billets-web): :hammer: do not use decodeURIComponent

### DIFF
--- a/apps/billets-web/app/event/[slug]/page.tsx
+++ b/apps/billets-web/app/event/[slug]/page.tsx
@@ -32,7 +32,7 @@ async function getEventMetadata(slug: string) {
     return null;
   }
   try {
-    const eventDetailData = await apiClient.event.getEventDetailBySlug(decodeURIComponent(slug));
+    const eventDetailData = await apiClient.event.getEventDetailBySlug(slug);
     if (!eventDetailData) {
       return null;
     }


### PR DESCRIPTION
# What's Changed

- remove decodeURIComponent because it already has been decoded on RSC side.